### PR TITLE
Fix several bugs; add tests

### DIFF
--- a/integ/test_librato.py
+++ b/integ/test_librato.py
@@ -153,6 +153,41 @@ class TestLibratoLegacy(object):
 
         assert expected_output == self.librato.gauges["baby-animals.active_sessions\tproduction.puppy-cam-1"]
 
+    def test_truncate_metric_name_for_legacy(self):
+        # 255 character limit
+        long_metric_name = 'a' * 300
+        truncated_metric_name = 'a' * 255
+        self.librato = build_librato({
+            "statsite_output": "gauges.%s|42.000000|1401577507" % long_metric_name,
+            "source": "myhost",
+            "write_to_legacy": True
+        })
+        expected_output = {
+            "name": truncated_metric_name,
+            "source": "myhost",
+            "measure_time": 1401577507,
+            "value": 42.0,
+        }
+        assert expected_output == self.librato.gauges[long_metric_name + "\tmyhost"]
+
+    def test_truncate_source_name_for_legacy(self):
+        # 255 character limit
+        long_source_name = 'a' * 300
+        truncated_source_name = 'a' * 255
+        self.librato = build_librato({
+            "statsite_output": "gauges.foo|42.000000|1401577507",
+            "source": long_source_name,
+            "write_to_legacy": True
+        })
+        expected_output = {
+            "name": "foo",
+            "source": truncated_source_name,
+            "measure_time": 1401577507,
+            "value": 42.0,
+        }
+        assert expected_output == self.librato.gauges["foo\t" + long_source_name]
+
+
 
 class TestLibrato(object):
     def setup_method(self, method):

--- a/sinks/librato.py
+++ b/sinks/librato.py
@@ -219,10 +219,6 @@ class LibratoStore(object):
         
 
     def add_measure(self, key, value, time):
-        # metric and source names must be 255 or fewer characters
-        if len(key) > 255:
-            key = key[:255]
-
         ts = int(time)
         if self.floor_time_secs != None:
             ts = (ts / self.floor_time_secs) * self.floor_time_secs

--- a/sinks/librato.py
+++ b/sinks/librato.py
@@ -293,8 +293,19 @@ class LibratoStore(object):
         # Build out the legacy gauges
         if self.write_to_legacy:
             if k not in self.gauges:
+                # Truncate metric/source names to 255 for legacy
+                if len(name) > 255:
+                    name = name[:255]
+                    self.logger.warning(
+                        "Truncating metric %s to 255 characters to avoid failing entire payload" % name
+                    )
+                if source and len(source) > 255:
+                    source = source[:255]
+                    self.logger.warning(
+                        "Truncating source %s to 255 characters to avoid failing entire payload" % source
+                    )
                 self.gauges[k] = {
-                    'name': name[:255],
+                    'name': name,
                     'source': source,
                     'measure_time': ts
                 }

--- a/sinks/librato.py
+++ b/sinks/librato.py
@@ -270,8 +270,9 @@ class LibratoStore(object):
             # Sanitize
             source = self.sanitize(source)
 
-            # Add a tag of source
-            tags['source'] = source
+            # Add a tag of source if not specified by the client
+            if 'source' not in tags:
+                tags['source'] = source
 
             # Build a key for the dict that will hold all the measurements to
             # submit

--- a/sinks/librato.py
+++ b/sinks/librato.py
@@ -411,7 +411,7 @@ class LibratoStore(object):
             if len(self.gauges) == 0:
                 return
             values = self.gauges.values()
-            
+            count = 0
             for measure in values:
                 legacy_metrics.append(measure)
                 count += 1


### PR DESCRIPTION
- Fixes a showstopper issue where the global variable `metrics` was being sent into the Librato payload, causing a 4xx 100% of the time.
- Allow multiple tagsets (datastreams) per tagged metric. Before this PR we were "last in wins" on a particular metric name which resulted in data loss.
- Allow `source` tag in measurement to override config-level source tag.
- Fix timers (summary statistics were not handled correctly)
- Revamp tests / write a ton of missing tests.